### PR TITLE
Add prettier to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
           - --fix=lf
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.2
+    hooks:
+      - id: prettier
+        types_or: [ html, css, javascript ]


### PR DESCRIPTION
In order to keep a code style throughout the source code, prettier was added to format html, css and js.