### PR TITLE
Add pint hook to pre-commit

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,23 @@
+name: QA
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Pull crazybolillo/phpint
+        run: docker pull crazybolillo/phpint
+      - name: Run Pint  # unknown, but fails on GH Actions as a pre-commit hook, therefore it runs separately
+        run: docker run --rm -v $PWD:/src:rw,Z --workdir /src crazybolillo/phpint --test
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: pre-commit/action@v3.0.0
+        env:
+          SKIP: phpint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
     hooks:
       - id: prettier
         types_or: [ html, css, javascript ]
+  - repo: https://github.com/crazybolillo/phpint
+    rev: v1.0.0
+    hooks:
+      - id: phpint


### PR DESCRIPTION
Laravel's Pint will now be part of the pre-commit hooks used for the CI pipeline.