### PR TITLE
FIX: ignore case when authorizing API requests

### DIFF
--- a/app/Http/Middleware/AuthenticateBoard.php
+++ b/app/Http/Middleware/AuthenticateBoard.php
@@ -34,8 +34,8 @@ class AuthenticateBoard
             throw new AuthenticationException();
         }
 
-        $uuid = $credentials[0];
-        $board = Board::where('uuid', $uuid)->first();
+        $uuid = strtoupper($credentials[0]);
+        $board = Board::whereUuid($uuid)->first();
         if (! $board) {
             throw new AuthenticationException();
         }

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -36,4 +36,9 @@ use Illuminate\Support\Carbon;
 class Board extends Model
 {
     use HasFactory;
+
+    public function setUuidAttribute(string $value): void
+    {
+        $this->attributes['uuid'] = strtoupper($value);
+    }
 }


### PR DESCRIPTION
The case of the provided UUID in the Authorization header is no longer takn into account when authorizing requests.