### PR TITLE
[REF] remove gradient columns from sessions models

### DIFF
--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -15,10 +15,7 @@ class SessionController extends Controller
         $validInput = $request->validate([
             'soak_temperature' => 'required|numeric',
             'soak_time' => 'required|numeric',
-            'reflow_gradient' => 'required|numeric',
-            'ramp_up_gradient' => 'required|numeric',
-            'reflow_max_time' => 'required|numeric',
-            'cooldown_gradient' => 'required|numeric',
+            'reflow_max_time' => 'nullable|numeric|gt:0',
             'reflow_peak_temp' => 'required|numeric',
         ]);
         $validInput['board_id'] = $requestBoard->id;

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -17,11 +17,8 @@ use Illuminate\Support\Carbon;
  * @property int $board_id
  * @property int $soak_temperature
  * @property int $soak_time
- * @property int $reflow_gradient
- * @property int $ramp_up_gradient
  * @property int $reflow_peak_temp
  * @property int $reflow_max_time
- * @property int $cooldown_gradient
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, Measurement> $measurements
@@ -30,11 +27,8 @@ use Illuminate\Support\Carbon;
  * @method static Builder|Session newQuery()
  * @method static Builder|Session query()
  * @method static Builder|Session whereBoardId($value)
- * @method static Builder|Session whereCooldownGradient($value)
  * @method static Builder|Session whereCreatedAt($value)
  * @method static Builder|Session whereId($value)
- * @method static Builder|Session whereRampUpGradient($value)
- * @method static Builder|Session whereReflowGradient($value)
  * @method static Builder|Session whereReflowMaxTime($value)
  * @method static Builder|Session whereReflowPeakTemp($value)
  * @method static Builder|Session whereSoakTemperature($value)
@@ -51,11 +45,17 @@ class Session extends Model
         'board_id',
         'soak_temperature',
         'soak_time',
-        'reflow_gradient',
         'reflow_max_time',
         'reflow_peak_temp',
-        'ramp_up_gradient',
-        'cooldown_gradient',
+    ];
+
+    /**
+     * Model's default values.
+     *
+     * @var int[]
+     */
+    protected $attributes = [
+        'reflow_max_time' => 90,
     ];
 
     /**

--- a/database/factories/SessionFactory.php
+++ b/database/factories/SessionFactory.php
@@ -20,13 +20,10 @@ class SessionFactory extends Factory
     {
         return [
             'board_id' => Board::factory(),
-            'ramp_up_gradient' => fake()->numberBetween(1, 3),
             'soak_time' => fake()->numberBetween(60, 120),
             'soak_temperature' => fake()->randomElement([90, 100, 110, 115]),
-            'reflow_gradient' => fake()->numberBetween(1, 3),
             'reflow_peak_temp' => fake()->randomElement([145, 150, 160, 170]),
             'reflow_max_time' => fake()->numberBetween(30, 80),
-            'cooldown_gradient' => fake()->numberBetween(1, 5),
         ];
     }
 }

--- a/database/migrations/2023_10_10_050446_remove_gradients_from_sessions_table.php
+++ b/database/migrations/2023_10_10_050446_remove_gradients_from_sessions_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->dropColumn('reflow_gradient');
+            $table->dropColumn('ramp_up_gradient');
+            $table->dropColumn('cooldown_gradient');
+        });
+    }
+};

--- a/database/seeders/MeasurementSeeder.php
+++ b/database/seeders/MeasurementSeeder.php
@@ -11,6 +11,11 @@ class MeasurementSeeder extends Seeder
 {
     use WithoutModelEvents;
 
+    private function randomFloat(float $min, float $max)
+    {
+        return rand($min * 100, $max * 100) / 100;
+    }
+
     /**
      * Run the database seeds.
      */
@@ -27,7 +32,7 @@ class MeasurementSeeder extends Seeder
                     'temperature' => $temp,
                     'sequence' => $sequence++,
                 ]);
-                $temp += $session->ramp_up_gradient;
+                $temp += $this->randomFloat(0.5, 2.5);
             }
 
             //Now we make soak time
@@ -47,7 +52,7 @@ class MeasurementSeeder extends Seeder
                     'temperature' => $temp,
                     'sequence' => ++$sequence,
                 ]);
-                $temp += $session->reflow_gradient;
+                $temp += $this->randomFloat(1, 2.5);
             }
 
             //Cool down ramp
@@ -57,7 +62,7 @@ class MeasurementSeeder extends Seeder
                     'temperature' => $temp,
                     'sequence' => ++$sequence,
                 ]);
-                $temp -= $session->cooldown_gradient;
+                $temp -= $this->randomFloat(2, 4);
             }
         }
     }

--- a/tests/Feature/ApiCreateSessionTest.php
+++ b/tests/Feature/ApiCreateSessionTest.php
@@ -30,10 +30,7 @@ class ApiCreateSessionTest extends TestCase
         $response = $this->postJson(route('api.session.store'), [
             'soak_temperature' => '10',
             'soak_time' => 1,
-            'reflow_gradient' => 4,
-            'ramp_up_gradient' => true,
-            'reflow_max_time' => 5,
-            'cooldown_gradient' => -6,
+            'reflow_max_time' => -5,
             'reflow_peak_temp' => '6',
         ], ['Authorization' => "Basic {$this->board->uuid}:{$this->board->uuid}"]);
 
@@ -47,15 +44,28 @@ class ApiCreateSessionTest extends TestCase
             [
                 'soak_time' => 70,
                 'soak_temperature' => 100,
-                'reflow_gradient' => 2,
                 'reflow_peak_temp' => 183,
                 'reflow_max_time' => 120,
-                'ramp_up_gradient' => 5,
-                'cooldown_gradient' => -6,
             ],
             ['Authorization' => "Basic {$this->board->uuid}:{$this->board->uuid}"]
         );
 
         $response->assertOk();
+    }
+
+    public function test_create_session_default_values(): void
+    {
+        $response = $this->postJson(
+            route('api.session.store'),
+            [
+                'soak_time' => 70,
+                'soak_temperature' => 100,
+                'reflow_peak_temp' => 183,
+            ],
+            ['Authorization' => "Basic {$this->board->uuid}:{$this->board->uuid}"]
+        );
+
+        $response->assertOk();
+        $response->assertJson(['reflow_max_time' => 90]);
     }
 }


### PR DESCRIPTION
The kind of poor man's reflow ovens that this app will work with at the moment are not capable of precisely controlling their temperature gradients, so it makes no sense to have them, its just more JSON payload data the potato MCU needs to send over.

BREAKING CHANGE: dropped columns from sessions table.