### PR TITLE
Create reflow artisan command to simulate a reflow session

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Next helper are designed due to on route/console.php looks like we can not declare functions
+ * that not belongs to Artisan class. So, these definitions are used for Artisan reflow command
+ * rc at the beginning of the function names means reflow command
+ */
+
+use App\Models\Measurement;
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+if (! function_exists('rcAddMeasurement')) {
+    function rcAddMeasurement(Collection &$measurements, int $sessionID, float $temp, int $sequence): void
+    {
+        $measurements->push([
+            'session_id' => $sessionID,
+            'temperature' => $temp,
+            'sequence' => $sequence,
+        ]);
+    }
+}
+
+if (! function_exists('rcSaveMeasurements')) {
+    function rcSaveMeasurements(Collection &$measurements, int $sleepTime, ProgressBar &$progress): void
+    {
+        if ($measurements->count() == 10) {
+            $measurements->map(function ($measurement) {
+                Measurement::create($measurement);
+            });
+            $measurements = collect();
+            $progress->advance(10);
+            sleep($sleepTime);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "bootstrap/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Models\Board;
+use App\Models\Measurement;
+use App\Models\Session;
 use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,6 +19,86 @@ use Illuminate\Support\Facades\Artisan;
 |
 */
 
+/*
+ * @var Illuminate\Support\Facades\Artisan $this
+ */
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+function addMeasurement(Collection &$measurements, int $sessionID, float $temp, int $sequence): void
+{
+    $measurements->push([
+        'session_id' => $sessionID,
+        'temperature' => $temp,
+        'sequence' => $sequence,
+    ]);
+}
+
+function saveMeasurements(Collection &$measurements, int $sleepTime, ProgressBar &$progress): void
+{
+    if ($measurements->count() == 10) {
+        $measurements->map(function ($measurement) {
+            Measurement::create($measurement);
+        });
+        $measurements = collect();
+        $progress->advance(10);
+        sleep($sleepTime);
+    }
+}
+/*
+ * @var Illuminate\Support\Facades\Artisan $this
+ * @var App\Models\Board $board
+ */
+Artisan::command('reflow {soakTemperature} {soakTime} {reflowPeakTemp} {sleepTime?} {reflowMaxTime?}', function ($soakTemperature, $soakTime, $reflowPeakTemp, $sleepTime = 10, $reflowMaxTime = 80) {
+    $board = Board::inRandomOrder()->limit(1)->first();
+
+    $progress = $this->getOutput()->createProgressBar($soakTime + $reflowPeakTemp + $soakTemperature);
+    $progress->setFormat("%message%\n %current%/%max% [%bar%] %percent:3s%%\n");
+    $progress->setMessage("Creating session on board {$board->name}");
+    $progress->start();
+
+    $session = Session::create([
+        'board_id' => $board->id,
+        'soak_time' => $soakTime,
+        'soak_temperature' => $soakTemperature,
+        'reflow_peak_temp' => $reflowPeakTemp,
+        'reflow_max_time' => $reflowMaxTime,
+    ]);
+
+    $temp = 20;
+    $measurements = collect();
+    $sequence = 1;
+
+    //Make ramp to soak
+    $progress->setMessage('Starting raising to soak temperature...');
+    while ($temp < $soakTemperature) {
+        addMeasurement($measurements, $session->id, $temp, $sequence++);
+        saveMeasurements($measurements, $sleepTime, $progress);
+        $temp += mt_rand(5, 25) / 10;
+    }
+
+    //Now we make soak time
+    $progress->setMessage('Keep on soak time...');
+    for ($seconds = 0; $seconds <= $soakTime; $seconds++, $sequence++) {
+        addMeasurement($measurements, $session->id, $temp, $sequence);
+        saveMeasurements($measurements, $sleepTime, $progress);
+    }
+
+    // Ramp up gradient to peak
+    $progress->setMessage('Ramp up to reflow peak temperature...');
+    while ($temp < $reflowPeakTemp) {
+        addMeasurement($measurements, $session->id, $temp, $sequence++);
+        saveMeasurements($measurements, $sleepTime, $progress);
+        $temp += mt_rand(10, 25) / 10;
+    }
+
+    //Cool down ramp
+    $progress->setMessage('Cooling down...');
+    while ($temp > 50) {
+        addMeasurement($measurements, $session->id, $temp, $sequence++);
+        saveMeasurements($measurements, $sleepTime, $progress);
+        $temp -= mt_rand(20, 40) / 10;
+    }
+    $progress->finish();
+})->purpose('Simulate reflow session');


### PR DESCRIPTION
With this reflow command we can simulate a session by setting reflow peak temperature, soak temperature and soak time, but also speed of the simulation in seconds per every database insertion.