### PR TITLE
Real time chart session

### DIFF
--- a/app/Http/Livewire/ActiveSession.php
+++ b/app/Http/Livewire/ActiveSession.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\Measurement;
+use App\Models\Session;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class ActiveSession extends Component
+{
+    public bool $activeSession = false;
+
+    public Session $session;
+
+    /** @var array<string> */
+    protected $listeners = [
+        'refresh' => '$refresh',
+    ];
+
+    public function test(): void
+    {
+        $this->activeSession = ! $this->activeSession;
+        $this->emitSelf('refresh');
+    }
+
+    /*
+     * @var App\Models\Session $lastSession
+     */
+    public function lastSession(): void
+    {
+        //Get last session from database and compare with now time
+        $lastSession = Session::orderBy('id', 'desc')->limit(1)->first();
+        if (($lastSession ?? false) and ! $this->activeSession) {
+            if (($lastSession->created_at ?? false) and $lastSession->created_at->diffInSeconds(now()) < 10) {
+                $this->activeSession = true;
+                $this->session = $lastSession;
+                $this->dispatchBrowserEvent('startActiveSessionUpdater');
+            }
+        }
+    }
+
+    public function sessionMeasurements(): void
+    {
+        //If session has started we need retrieve all measurements for this session
+        //And at the same check created_at of this measurements
+        if ($this->activeSession) {
+            $measurements = Measurement::where('session_id', $this->session->id)
+                ->get();
+            if ($measurements->count() > 0) {
+                $msmnCrDate = $measurements->last()->created_at ?? false;
+                if ($msmnCrDate and $msmnCrDate->diffInSeconds(now()) < 50) {
+                    $dataToSend = $measurements->map(function ($m) {
+                        return (float) $m->temperature;
+                    })->toArray();
+                    $this->dispatchBrowserEvent('getSessionMeasurements', $dataToSend);
+                }
+            }
+        }
+    }
+
+    public function boot(): void
+    {
+        $this->activeSession = false;
+    }
+
+    public function render(): view
+    {
+        return view('livewire.active-session');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "laravel/breeze": "^1.23",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.2",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "livewire/livewire": "2.X"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1ca2d4b29a7c04017bb99129029a8d4",
+    "content-hash": "6685e86b755b1b6cdf5dc16b412d5045",
     "packages": [
         {
             "name": "brick/math",
@@ -1866,6 +1866,79 @@
                 }
             ],
             "time": "2023-08-05T12:09:49+00:00"
+        },
+        {
+            "name": "livewire/livewire",
+            "version": "v2.12.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "7d3a57b3193299cf1a0639a3935c696f4da2cf92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/7d3a57b3193299cf1a0639a3935c696f4da2cf92",
+                "reference": "7d3a57b3193299cf1a0639a3935c696f4da2cf92",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
+                "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
+                "league/mime-type-detection": "^1.9",
+                "php": "^7.2.5|^8.0",
+                "symfony/http-kernel": "^5.0|^6.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
+                "orchestra/testbench-dusk": "^5.2|^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^8.4|^9.0",
+                "psy/psysh": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ],
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v2.12.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-11T04:02:34+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -89,23 +89,12 @@
                     @endforelse
                 </div>
                 {{-- Current session --}}
-                <div class="dark:text-white text-center rounded-lg
-                         dark:shadow-[0_0_5px_1px_rgba(255,255,255,0.3)] pt-8 pb-4
-                         transition-all duration-150 transform hover:scale-[1.02] cursor-pointer
-                         bg-white dark:bg-gray-800
-                         lightBox
-                         "
-                >
-                    <object class="hidden dark:block mx-auto h-[150px]" data="{{asset('img/circuit_package_white.svg')}}" width="80%"></object>
-                    <object class="block dark:hidden mx-auto h-[150px]" data="{{asset('img/circuit_package.svg')}}" width="80%"></object>
-                    <p class="w-full mt-2 text-xl">No active sessions</p>
-                    <p>When a session starts here will be shown</p>
-                </div>
+                @livewire('active-session')
             </div>
         </div>
 
         {{-- Last session hart and statistics --}}
-        <div class="max-w-8xl mx-auto sm:px-6 lg:px-8 shadow mt-8">
+        <div class="max-w-8xl mx-auto shadow mt-8">
             <div class="grid md:grid-cols-2 gap-6">
                 <div class=" sm:rounded-lg">
                     <div class="grid md:grid-cols-3 gap-6">
@@ -270,7 +259,7 @@
                 //We add event when changing switch light mode
                 document.querySelector('#switchLight').addEventListener('click', (e) =>{
                     let opt;
-                    if( JSON.parse(localStorage.getItem('darkMode')) ){
+                    if(!JSON.parse(localStorage.getItem('darkMode'))){
                         yColor = '#E5E7EB'
                         titleColor = '#E5E7EB'
                     }
@@ -290,6 +279,7 @@
                         }
                     }
                     chart.updateOptions(opt, false, false)
+                    activeSessionChart.updateOptions(opt, true, true, true)
                 })
             </script>
             @endnotEmpty

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -41,6 +41,19 @@
         .afterLongSession:after{background-color: #3af81f !important;}
         .afterMostSessions:after{background-color: #00a2e6 !important;}
 
+        .apexcharts-title-text{
+            fill: black;
+        }
+        .dark .apexcharts-title-text{
+            fill: white;
+        }
+        .apexcharts-yaxis-texts-g text, .apexcharts-xaxis-texts-g text{
+            fill: black;
+        }
+        .dark .apexcharts-yaxis-texts-g text, .dark .apexcharts-xaxis-texts-g text{
+            fill: white;
+        }
+
     </style>
 
     <div class="py-12 mx-4">
@@ -94,7 +107,7 @@
         </div>
 
         {{-- Last session hart and statistics --}}
-        <div class="max-w-8xl mx-auto shadow mt-8">
+        <div class="max-w-8xl mx-auto mt-8 sm:px-6 lg:px-8">
             <div class="grid md:grid-cols-2 gap-6">
                 <div class=" sm:rounded-lg">
                     <div class="grid md:grid-cols-3 gap-6">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,7 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @livewireStyles
     </head>
     <body class="font-sans antialiased" x-data="{ darkMode: false }" x-init="
     if (!('darkMode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches) {
@@ -43,5 +44,6 @@
             <x-preloader></x-preloader>
         </div>
     </div>
+    @livewireScripts
     </body>
 </html>

--- a/resources/views/livewire/active-session.blade.php
+++ b/resources/views/livewire/active-session.blade.php
@@ -13,7 +13,7 @@
         <object class="hidden dark:block mx-auto h-[150px]" data="{{asset('img/circuit_package_white.svg')}}" width="80%"></object>
         <object class="block dark:hidden mx-auto h-[150px]" data="{{asset('img/circuit_package.svg')}}" width="80%"></object>
         <p class="w-full mt-2 text-xl">No active sessions</p>
-        <p wire:click="test">When a session starts here will be shown</p>
+        <p>When a session starts here will be shown</p>
     </div>
     <div wire:ignore.self id="activeSessionDom" class="hidden bg-white dark:bg-gray-800 overflow-hidden sm:rounded-lg bg-[#01273e] lightBox shadow transition-all duration-150 transform hover:scale-[1.02] cursor-pointer dark:shadow-[0_0_5px_1px_rgba(255,255,255,0.3)]">
         <div class="grid grid-cols-3 mt-3">
@@ -21,14 +21,19 @@
             <div>
                 @if($activeSession)
                     <span class="bg-green-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(0,255,137,0.5)]">LIVE</span>
-                    <span wire:click="test" class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)] ml-3">FINISHED</span>
+                    <span class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)] ml-3">FINISHED</span>
                 @else
                     <span class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)]">LIVE</span>
-                    <span wire:click="test" class="bg-red-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(255,98,7,0.5)] ml-3">FINISHED</span>
+                    <span class="bg-red-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(255,98,7,0.5)] ml-3">FINISHED</span>
                 @endif
             </div>
-            <div class="justify-items-end" wire:ignore>
-                <span class="bg-red-400 dark:text-white text-2xl px-[10px] rounded-md absolute right-0 top-[8px] mr-5 shadow-[0_0_5px_1px_rgba(255,98,7,0.5)]">&times;</span>
+            <div class="justify-items-end">
+                @if(!$activeSession)
+                <span
+                    class="bg-red-400 dark:text-white text-2xl px-[10px] rounded-md absolute right-0 top-[8px] mr-5 shadow-[0_0_5px_1px_rgba(255,98,7,0.5)]"
+                    onclick="closeChartActiveSession()"
+                >&times;</span>
+                @endif
             </div>
         </div>
         <div wire:ignore id="activeSessionChart" class="h-[250] mx-3 mt-3"></divwire:ignore>
@@ -42,7 +47,15 @@
 
         function stopActiveSessionChart(){
             clearInterval(activeSessionUpdater)
+            activeSessionUpdater = null
             console.log('Active Session Updater Stopped')
+        }
+
+        function closeChartActiveSession(){
+            let noActiveMessage = document.querySelector('#noActiveSessionMessage')
+            let activeSessionDom = document.querySelector('#activeSessionDom')
+            noActiveMessage.classList.remove('hidden')
+            activeSessionDom.classList.add('hidden')
         }
 
         //Event to start showing graph
@@ -63,8 +76,19 @@
 
         //Event to receive session measurements and append to graph
         window.addEventListener('getSessionMeasurements', (e) => {
-            console.log(e.detail)
+            //console.log(e.detail)
             yData = e.detail
+        })
+
+        //Event to stop interval javascript who updates chart data
+        window.addEventListener('stopActiveSessionUpdater', (e) =>{
+            let pollerLastSession = document.querySelector('#pollerLastSession')
+            let pollerSessionMeasurements = document.querySelector('#pollerSessionMeasurements')
+
+            stopActiveSessionChart()
+            pollerLastSession.classList.remove('hidden')
+            pollerSessionMeasurements.classList.add('hidden')
+            yData = []
         })
 
         let activeSessionUpdater = null //Interval to update the active session chart

--- a/resources/views/livewire/active-session.blade.php
+++ b/resources/views/livewire/active-session.blade.php
@@ -1,0 +1,146 @@
+<div>
+    <div wire:ignore wire:poll.visible="lastSession" id="pollerLastSession"></div>
+    <div wire:ignore wire:poll.visible="sessionMeasurements" id="pollerSessionMeasurements" class="hidden"></div>
+    <div class="dark:text-white text-center rounded-lg
+                         dark:shadow-[0_0_5px_1px_rgba(255,255,255,0.3)] pt-8 pb-4
+                         transition-all duration-150 transform hover:scale-[1.02] cursor-pointer
+                         bg-white dark:bg-gray-800
+                         lightBox
+                         "
+         id="noActiveSessionMessage"
+         wire:ignore
+    >
+        <object class="hidden dark:block mx-auto h-[150px]" data="{{asset('img/circuit_package_white.svg')}}" width="80%"></object>
+        <object class="block dark:hidden mx-auto h-[150px]" data="{{asset('img/circuit_package.svg')}}" width="80%"></object>
+        <p class="w-full mt-2 text-xl">No active sessions</p>
+        <p wire:click="test">When a session starts here will be shown</p>
+    </div>
+    <div wire:ignore.self id="activeSessionDom" class="hidden bg-white dark:bg-gray-800 overflow-hidden sm:rounded-lg bg-[#01273e] lightBox shadow transition-all duration-150 transform hover:scale-[1.02] cursor-pointer dark:shadow-[0_0_5px_1px_rgba(255,255,255,0.3)]">
+        <div class="grid grid-cols-3 mt-3">
+            <div> </div>
+            <div>
+                @if($activeSession)
+                    <span class="bg-green-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(0,255,137,0.5)]">LIVE</span>
+                    <span wire:click="test" class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)] ml-3">FINISHED</span>
+                @else
+                    <span class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)]">LIVE</span>
+                    <span wire:click="test" class="bg-red-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(255,98,7,0.5)] ml-3">FINISHED</span>
+                @endif
+            </div>
+            <div class="justify-items-end" wire:ignore>
+                <span class="bg-red-400 dark:text-white text-2xl px-[10px] rounded-md absolute right-0 top-[8px] mr-5 shadow-[0_0_5px_1px_rgba(255,98,7,0.5)]">&times;</span>
+            </div>
+        </div>
+        <div wire:ignore id="activeSessionChart" class="h-[250] mx-3 mt-3"></divwire:ignore>
+    </div>
+
+    <script type="text/javascript">
+        function updateActiveSessionChart(){
+            activeSessionChart.updateSeries([{data: yData}])
+            activeSessionChart.updateOptions({yaxis:{max: Math.max(...yData) + 2}})
+        }
+
+        function stopActiveSessionChart(){
+            clearInterval(activeSessionUpdater)
+            console.log('Active Session Updater Stopped')
+        }
+
+        //Event to start showing graph
+        window.addEventListener('startActiveSessionUpdater', (e) => {
+            let noActiveMessage = document.querySelector('#noActiveSessionMessage')
+            let activeSessionDom = document.querySelector('#activeSessionDom')
+            let pollerLastSession = document.querySelector('#pollerLastSession')
+            let pollerSessionMeasurements = document.querySelector('#pollerSessionMeasurements')
+
+            noActiveMessage.classList.add('hidden')
+            activeSessionDom.classList.remove('hidden')
+            pollerLastSession.classList.add('hidden')
+            pollerSessionMeasurements.classList.remove('hidden')
+
+            activeSessionUpdater = setInterval(updateActiveSessionChart, 1000)
+            console.log('Active Session Updater Started')
+        })
+
+        //Event to receive session measurements and append to graph
+        window.addEventListener('getSessionMeasurements', (e) => {
+            console.log(e.detail)
+            yData = e.detail
+        })
+
+        let activeSessionUpdater = null //Interval to update the active session chart
+
+        //Check dark mode
+        let yColor, titleColor
+        if(JSON.parse(localStorage.getItem('darkMode'))){
+            yColor = '#E5E7EB'
+            titleColor = '#E5E7EB'
+        }
+        else{
+            yColor = '#111827'
+            titleColor = '#111827'
+        }
+
+        var yData = [] //Active session data
+        var xData = []
+        let options = {
+            series: [{
+                name: '°C',
+                data: yData.slice(),
+            }],
+            chart: {
+                height: 250,
+                width: '100%',
+                type: 'line',
+                animations: {
+                    enabled: false,
+                    easing: 'linear',
+                    dynamicAnimation: {
+                        enabled: true,
+                        speed: 3000
+                    }
+                },
+                foreColor: yColor,
+            },
+            forecastDataPoints: {
+                count: 7
+            },
+            stroke: {
+                width: 5,
+                curve: 'smooth'
+            },
+            xaxis: {
+                type: 'numeric',
+                tickAmount: 10
+            },
+            title: {
+                text: "Active session",
+                align: 'left',
+                style: {
+                    fontSize: "16px",
+                    color: titleColor
+                }
+            },
+            fill: {
+                type: 'gradient',
+                gradient: {
+                    shade: 'dark',
+                    gradientToColors: [ '#FDD835'],
+                    shadeIntensity: 1,
+                    type: 'horizontal',
+                    opacityFrom: 1,
+                    opacityTo: 1,
+                    stops: [0, 100, 100, 100]
+                },
+            },
+            yaxis: {
+                min: 0,
+                max: Math.max(yData) + 10
+            }
+        };
+        var activeSessionChart
+    </script>
+    <script type="module">
+        activeSessionChart = new ApexCharts(document.querySelector("#activeSessionChart"), options);
+        activeSessionChart.render();
+    </script>
+</div>

--- a/resources/views/livewire/active-session.blade.php
+++ b/resources/views/livewire/active-session.blade.php
@@ -18,12 +18,12 @@
     <div wire:ignore.self id="activeSessionDom" class="hidden bg-white dark:bg-gray-800 overflow-hidden sm:rounded-lg bg-[#01273e] lightBox shadow transition-all duration-150 transform hover:scale-[1.02] cursor-pointer dark:shadow-[0_0_5px_1px_rgba(255,255,255,0.3)]">
         <div class="grid grid-cols-3 mt-3">
             <div> </div>
-            <div>
+            <div class="flex justify-center">
                 @if($activeSession)
                     <span class="bg-green-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(0,255,137,0.5)]">LIVE</span>
-                    <span class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)] ml-3">FINISHED</span>
+                    <span class="bg-gray-300 dark:bg-gray-700 text-white dark:text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)] ml-3">FINISHED</span>
                 @else
-                    <span class="bg-gray-700 text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)]">LIVE</span>
+                    <span class="bg-gray-300 dark:bg-gray-700 text-white dark:text-gray-500 p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(79,83,81,0.5)]">LIVE</span>
                     <span class="bg-red-600 text-white p-[5px] rounded-md shadow-[0_0_5px_1px_rgba(255,98,7,0.5)] ml-3">FINISHED</span>
                 @endif
             </div>
@@ -36,7 +36,8 @@
                 @endif
             </div>
         </div>
-        <div wire:ignore id="activeSessionChart" class="h-[250] mx-3 mt-3"></divwire:ignore>
+        <p class="h4 mt-3 text-center text-white"> Active session on {{$sessionBoardName}}</p>
+        <div wire:ignore id="activeSessionChart" class="h-[250] mx-3 mt-3"></div>
     </div>
 
     <script type="text/javascript">
@@ -135,14 +136,6 @@
             xaxis: {
                 type: 'numeric',
                 tickAmount: 10
-            },
-            title: {
-                text: "Active session",
-                align: 'left',
-                style: {
-                    fontSize: "16px",
-                    color: titleColor
-                }
             },
             fill: {
                 type: 'gradient',


### PR DESCRIPTION
This PR add the necessary logic to listen for session start requests on client side and show "real time" chart while the session keeps adding measurements to database. When session finishes, let close chart and keep listen for new incoming session requests.